### PR TITLE
Clarify order of entity/numeric character references vs. delimiter runs

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5659,6 +5659,10 @@ with the following exceptions:
   `*` in emphasis delimiters, bullet list markers, or thematic
   breaks.
 
+- Entity and numeric character references are replaced before
+  deciding whether a [delimiter run] can open and/or close
+  emphasis.
+
 Conforming CommonMark parsers need not store information about
 whether a particular character was represented in the source
 using a Unicode character or an entity reference.
@@ -5796,6 +5800,16 @@ text in code spans and code blocks:
 .
 <pre><code>f&amp;ouml;f&amp;ouml;
 </code></pre>
+````````````````````````````````
+
+
+Entity and numeric character references are replaced before deciding
+whether a [delimiter run] can open and/or close emphasis.
+
+```````````````````````````````` example
+i*&#105;i*i
+.
+<p>i<em>ii</em>i</p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
See #474 and https://talk.commonmark.org/t/when-exactly-should-numeric-character-references-be-replaced/2121