### PR TITLE
fix v0.29 example-91

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1668,7 +1668,7 @@ Fewer than three backticks is not enough:
 foo
 ``
 .
-<p><code>foo</code></p>
+foo
 ````````````````````````````````
 
 The closing code fence must use the same character as the opening


### PR DESCRIPTION
This example is described as "Fewer than three backticks is not enough". The example's input has only two backticks, but the output incorrectly shows it outputting a pre/code block. https://spec.commonmark.org/0.29/#example-91