### PR TITLE
Remove superfluous restrictions on declarations

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2389,7 +2389,7 @@ need not match the start tag).
 **End condition:** line contains the string `?>`.
 
 4.  **Start condition:** line begins with the string `<!`
-followed by an uppercase ASCII letter.\
+followed by an ASCII letter.\
 **End condition:** line contains the character `>`.
 
 5.  **Start condition:**  line begins with the string
@@ -8947,10 +8947,8 @@ consists of the string `<?`, a string
 of characters not including the string `?>`, and the string
 `?>`.
 
-A [declaration](@) consists of the
-string `<!`, a name consisting of one or more uppercase ASCII letters,
-[whitespace], a string of characters not including the
-character `>`, and the character `>`.
+A [declaration](@) consists of the string `<!`, an ASCII letter, zero or more
+characters not including the character `>`, and the character `>`.
 
 A [CDATA section](@) consists of
 the string `<![CDATA[`, a string of characters not including the string


### PR DESCRIPTION
This PR removes superfluous restrictions on declarations that CM currently imposes, whereas HTML is more relaxed.

This is mostly useful because `<!doctype html>` can be used in HTML, but couldn’t be used in CM before.
Theoretically, this could make more user input HTML, which could be a slight problem. However, practically, I feel that the string `<!` is clear in intent, and uncommon enough in Markdown, that it shouldn’t cause too much breakage.

Related to GH-620.