### PR TITLE
Change paragraph to plural

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -3538,7 +3538,7 @@ ddd</p>
 ````````````````````````````````
 
 
-Multiple blank lines between paragraph have no effect:
+Multiple blank lines between paragraphs have no effect:
 
 ```````````````````````````````` example
 aaa


### PR DESCRIPTION
It is tough for something to be "between paragraph", since "paragraph" is singular and there must be at least two of them for something to be between them.