### PR TITLE
Add a few examples illustrating that zero-width space is not an equivalent of backslash escape

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -622,6 +622,8 @@ foo
 
 ## Zero-width space escapes
 
+For most use-cases requiring an escape it's worth considering using backslash escapes first, but zero-width space escapes can useful sometimes as well.
+
 Zero width space can be used to ensure emphasis in East Asian text:
 
 ```````````````````````````````` example

--- a/spec.txt
+++ b/spec.txt
@@ -644,6 +644,30 @@ such as mixed bold/italic mark-up:
 ````````````````````````````````
 
 
+Zero-width space can be used to escape an indicator of inline structure with content:
+```````````````````````````````` example
+2&#x200B;*3&#x200B;*4 = 20
+.
+<p>2​*3​*4 = 20</p>
+````````````````````````````````
+
+
+However, unlike backslash escapes, zero-width space cannot be used to escape each in a series of consecutive indicators of inline structure:
+```````````````````````````````` example
+2&#x200B;*&#x200B;*3&#x200B;*&#x200B;*4 = 4096
+.
+<p>2​*​<em>3​</em>​*4 = 4096</p>
+````````````````````````````````
+
+
+Instead, it would be necessary to escape only the initial indicator of inline structure in a set of consecutive indicators:
+```````````````````````````````` example
+2&#x200B;**3&#x200B;**4 = 4096
+.
+<p>2​**3​**4 = 4096</p>
+````````````````````````````````
+
+
 ## Entity and numeric character references
 
 Valid HTML entity references and numeric character references

--- a/spec.txt
+++ b/spec.txt
@@ -620,6 +620,28 @@ foo
 ````````````````````````````````
 
 
+## Zero-width space escapes
+
+Zero width space can be used to ensure emphasis in East Asian text:
+
+```````````````````````````````` example
+棕色*狐狸。*&#x200b;跳过
+.
+<p>棕色<em>狐狸。</em>​跳过</p>
+````````````````````````````````
+
+
+Zero width space escapes can also be used in to achieve some combined effects
+such as mixed bold/italic mark-up:
+
+```````````````````````````````` example
+**bold*bold-italic***&#x200B;*italic*&#x200B;***bold-italic*bold**
+.
+<p><strong>bold<em>bold-italic</em></strong>​<em>italic</em>​<strong><em>bold-italic</em>bold</strong></p>
+
+````````````````````````````````
+
+
 ## Entity and numeric character references
 
 Valid HTML entity references and numeric character references

--- a/spec.txt
+++ b/spec.txt
@@ -646,7 +646,8 @@ bold/italic mark-up:
 ````````````````````````````````
 
 
-Zero-width space can be used to escape an indicator of inline structure with content:
+Zero-width space can be used to escape an indicator of inline structure with
+content:
 ```````````````````````````````` example
 2&#x200B;*3&#x200B;*4 = 20
 .
@@ -654,7 +655,8 @@ Zero-width space can be used to escape an indicator of inline structure with con
 ````````````````````````````````
 
 
-However, unlike backslash escapes, zero-width space cannot be used to escape each in a series of consecutive indicators of inline structure:
+However, unlike backslash escapes, zero-width space cannot be used to escape
+each in a series of consecutive indicators of inline structure:
 ```````````````````````````````` example
 2&#x200B;*&#x200B;*3&#x200B;*&#x200B;*4 = 4096
 .
@@ -662,7 +664,8 @@ However, unlike backslash escapes, zero-width space cannot be used to escape eac
 ````````````````````````````````
 
 
-Instead, it would be necessary to escape only the initial indicator of inline structure in a set of consecutive indicators:
+Instead, it would be necessary to escape only the initial indicator of inline
+structure in a set of consecutive such indicators:
 ```````````````````````````````` example
 2&#x200B;**3&#x200B;**4 = 4096
 .

--- a/spec.txt
+++ b/spec.txt
@@ -620,9 +620,11 @@ foo
 ````````````````````````````````
 
 
-## Zero-width space (escapes)
+## Zero-width space
 
-For most use-cases requiring escapes it's worth considering using backslash escapes, but zero-width space can be useful sometimes as well (including as an escape character).
+For most use-cases requiring escapes it's worth considering using backslash
+escapes, but zero-width space can be useful sometimes as well (to change the
+meaning of a neighboring character).
 
 Zero-width space can be used to ensure emphasis in East Asian text:
 
@@ -633,8 +635,8 @@ Zero-width space can be used to ensure emphasis in East Asian text:
 ````````````````````````````````
 
 
-Zero-width space escapes can also be used to achieve some combined effects
-such as mixed bold/italic mark-up:
+Zero-width space can also be used to achieve some combined effects such as mixed
+bold/italic mark-up:
 
 ```````````````````````````````` example
 **bold*bold-italic***&#x200B;*italic*&#x200B;***bold-italic*bold**

--- a/spec.txt
+++ b/spec.txt
@@ -620,11 +620,11 @@ foo
 ````````````````````````````````
 
 
-## Zero-width space escapes
+## Zero-width space (escapes)
 
-For most use-cases requiring an escape it's worth considering using backslash escapes first, but zero-width space escapes can useful sometimes as well.
+For most use-cases requiring escapes it's worth considering using backslash escapes, but zero-width space can be useful sometimes as well (including as an escape character).
 
-Zero width space can be used to ensure emphasis in East Asian text:
+Zero-width space can be used to ensure emphasis in East Asian text:
 
 ```````````````````````````````` example
 棕色*狐狸。*&#x200b;跳过
@@ -633,7 +633,7 @@ Zero width space can be used to ensure emphasis in East Asian text:
 ````````````````````````````````
 
 
-Zero width space escapes can also be used in to achieve some combined effects
+Zero-width space escapes can also be used to achieve some combined effects
 such as mixed bold/italic mark-up:
 
 ```````````````````````````````` example


### PR DESCRIPTION
Fixes: commonmark-spec#643