### PR TITLE
Remove duplicate links in spec

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -851,8 +851,8 @@ one block element does not affect the inline parsing of any other.
 ## Container blocks and leaf blocks
 
 We can divide blocks into two types:
-[container blocks](@),
-which can contain other blocks, and [leaf blocks](@),
+[container blocks](#container-blocks),
+which can contain other blocks, and [leaf blocks](#leaf-blocks),
 which cannot.
 
 # Leaf blocks


### PR DESCRIPTION
Change link targets in section 2.3 (Container blocks and leaf blocks) to fix links to Container blocks and Leaf blocks.

See: #654 