### PR TITLE
fix `normalize.py` for python 3.8

### DIFF
--- a/test/normalize.py
+++ b/test/normalize.py
@@ -13,7 +13,7 @@ except ImportError:
 from html.entities import name2codepoint
 import sys
 import re
-import cgi
+import html
 
 # Normalization code, adapted from
 # https://github.com/karlcow/markdown-testsuite/
@@ -66,7 +66,7 @@ class MyHTMLParser(HTMLParser):
                     self.output += ("=" + '"' +
                             urllib.quote(urllib.unquote(v), safe='/') + '"')
                 elif v != None:
-                    self.output += ("=" + '"' + cgi.escape(v,quote=True) + '"')
+                    self.output += ("=" + '"' + html.escape(v,quote=True) + '"')
         self.output += ">"
         self.last_tag = tag
         self.last = "starttag"


### PR DESCRIPTION
This was filed as https://github.com/commonmark/cmark/issues/313 in the `commonmark/cmark` repo, and fixed in https://github.com/commonmark/cmark/commit/68c3a91166347a32a57fb81223750a63cfd92105. This PR merely applies the same patch to `normalize.py` in this repo.