### PR TITLE
Provide a test example for '---' in a code fence.

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2237,6 +2237,26 @@ aaa
 ````````````````````````````````
 
 
+Within a code fence, other block-level constructs such as lists or thematic
+breaks are ignored.
+
+```````````````````````````````` example
+yaml:
+- A
+- yaml
+- list
+---
+another: "yaml doc"
+.
+<pre><code>yaml:
+- A
+- yaml
+- list
+---
+another: "yaml doc"</code></pre>
+````````````````````````````````
+
+
 Fenced code blocks can interrupt paragraphs, and can be followed
 directly by paragraphs, without a blank line between:
 


### PR DESCRIPTION
I found [this issue](https://github.com/knative/docs/issues/2706) in [Goldmark](https://github.com/yuin/goldmark), and the spec seems pretty clear, so I thought I'd add a test case.