### PR TITLE
Fix missing space

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -9284,10 +9284,10 @@ bar</em></p>
 Hard line breaks do not occur inside code spans
 
 ```````````````````````````````` example
-`code 
+`code  
 span`
 .
-<p><code>code  span</code></p>
+<p><code>code   span</code></p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
The example that illustrates hard breaks cannot occur in code spans, can’t turn into a hard break, as it has a space too few.