### PR TITLE
clarify that character references are not interpreted in HTML blocks and raw HTML

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -722,16 +722,41 @@ recognized as entity references either:
 ````````````````````````````````
 
 
-Entity and numeric character references are recognized in any
-context besides code spans or code blocks, including
-URLs, [link titles], and [fenced code block][] [info strings]:
+Entity and numeric character references are treated as literal
+text in code spans and code blocks:
 
 ```````````````````````````````` example
-<a href="&ouml;&ouml;.html">
+`f&ouml;&ouml;`
 .
-<a href="&ouml;&ouml;.html">
+<p><code>f&amp;ouml;&amp;ouml;</code></p>
 ````````````````````````````````
 
+
+```````````````````````````````` example
+    f&ouml;f&ouml;
+.
+<pre><code>f&amp;ouml;f&amp;ouml;
+</code></pre>
+````````````````````````````````
+
+
+
+Entity and numeric character references are left uninterpreted
+in HTML blocks and raw HTML:
+
+```````````````````````````````` example
+<div id="&copy&asdf;">
+
+Link <a href="&copy&ouml;&ouml;.html">
+.
+<div id="&copy&asdf;">
+<p>Link <a href="&copy&ouml;&ouml;.html"></p>
+````````````````````````````````
+
+
+Entity and numeric character references are recognized in any
+any other context, including URLs, [link titles], and
+[fenced code block][] [info strings]:
 
 ```````````````````````````````` example
 [foo](/f&ouml;&ouml; "f&ouml;&ouml;")
@@ -755,24 +780,6 @@ foo
 ```
 .
 <pre><code class="language-föö">foo
-</code></pre>
-````````````````````````````````
-
-
-Entity and numeric character references are treated as literal
-text in code spans and code blocks:
-
-```````````````````````````````` example
-`f&ouml;&ouml;`
-.
-<p><code>f&amp;ouml;&amp;ouml;</code></p>
-````````````````````````````````
-
-
-```````````````````````````````` example
-    f&ouml;f&ouml;
-.
-<pre><code>f&amp;ouml;f&amp;ouml;
 </code></pre>
 ````````````````````````````````
 
@@ -9173,17 +9180,17 @@ foo <![CDATA[>&<]]>
 ````````````````````````````````
 
 
-Entity and numeric character references are preserved in HTML
+Entity and numeric character references are copied uninterpreted in HTML
 attributes:
 
 ```````````````````````````````` example
-foo <a href="&ouml;">
+foo <a href="&ouml;&copy">
 .
-<p>foo <a href="&ouml;"></p>
+<p>foo <a href="&ouml;&copy"></p>
 ````````````````````````````````
 
 
-Backslash escapes do not work in HTML attributes:
+Backslash escapes are also copied uninterpreted:
 
 ```````````````````````````````` example
 foo <a href="\*">
@@ -9191,6 +9198,9 @@ foo <a href="\*">
 <p>foo <a href="\*"></p>
 ````````````````````````````````
 
+
+Not interpreting backslash escapes can mean not recognizing
+a tag that HTML5 would recognize:
 
 ```````````````````````````````` example
 <a href="\"">


### PR DESCRIPTION
The wording in section 2.5 implied otherwise,
although an example in 6.6 did clarify.
Adjust the first to remove the false implication
and adjust the second from saying "preserved",
which might mean they have to be parsed first,
to "copied uninterpreted".

The diff makes a bit of a hash of the changes,
which are to move the "unrecognized" cases
above the recognized ones, as suggested in #687.

Fixes #687.