### PR TITLE
cmark.py: make previous API change backwards compatible

### DIFF
--- a/test/cmark.py
+++ b/test/cmark.py
@@ -1,26 +1,35 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""
+The CMark library (https://github.com/commonmark/cmark) uses the same API so
+changes made here should be made backwards-compatible to facilitate porting.
+"""
 
 from ctypes import CDLL, c_char_p, c_long
 from subprocess import *
 import platform
 import os
 
-def pipe_through_prog(prog, text):
+def pipe_through_prog(prog, text, decode):
     p1 = Popen(prog.split(), stdout=PIPE, stdin=PIPE, stderr=PIPE)
     [result, err] = p1.communicate(input=text.encode('utf-8'))
+    if decode:
+        result = result.decode('utf-8')
     return [p1.returncode, result, err]
 
-def use_library(lib, text):
+def use_library(lib, text, decode):
     textbytes = text.encode('utf-8')
     textlen = len(textbytes)
-    return [0, lib(textbytes, textlen, 0), '']
+    result = lib(textbytes, textlen, 0)
+    if decode:
+        result = result.decode('utf-8')
+    return [0, result, '']
 
 class CMark:
-    def __init__(self, prog=None, library_dir=None):
+    def __init__(self, prog=None, library_dir=None, decode_html=True):
         self.prog = prog
         if prog:
-            self.to_html = lambda x: pipe_through_prog(prog, x)
+            self.to_html = lambda x: pipe_through_prog(prog, x, decode_html)
         else:
             sysname = platform.system()
             if sysname == 'Darwin':
@@ -37,4 +46,4 @@ class CMark:
             markdown = cmark.cmark_markdown_to_html
             markdown.restype = c_char_p
             markdown.argtypes = [c_char_p, c_long]
-            self.to_html = lambda x: use_library(markdown, x)
+            self.to_html = lambda x: use_library(markdown, x, decode_html)

--- a/test/spec_tests.py
+++ b/test/spec_tests.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
         exit(0)
     else:
         skipped = len(all_tests) - len(tests)
-        cmark = CMark(prog=args.program, library_dir=args.library_dir)
+        cmark = CMark(prog=args.program, library_dir=args.library_dir, decode_html=False)
         result_counts = {'pass': 0, 'fail': 0, 'error': 0, 'skip': skipped}
 
         previous = {}


### PR DESCRIPTION
In ec132903e20b8645e6c8e1979c36c9470c4c35ec I changed cmark.py
without knowing that the CMark library also has a cmark.py
and changes here should be easily portable to CMark.
This commit remedies that oversight.

Edit: Marking this as a draft for now, see discussion in #698.