### PR TITLE
Remove `source` element as HTML block start condition

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2403,7 +2403,7 @@ followed by one of the strings (case-insensitive) `address`,
 `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `head`, `header`, `hr`,
 `html`, `iframe`, `legend`, `li`, `link`, `main`, `menu`, `menuitem`,
 `nav`, `noframes`, `ol`, `optgroup`, `option`, `p`, `param`,
-`section`, `source`, `summary`, `table`, `tbody`, `td`,
+`section`, `summary`, `table`, `tbody`, `td`,
 `tfoot`, `th`, `thead`, `title`, `tr`, `track`, `ul`, followed
 by a space, a tab, the end of the line, the string `>`, or
 the string `/>`.\


### PR DESCRIPTION
Following up on a [conversation on talk.commonmark.org](https://talk.commonmark.org/t/ensure-picture-is-not-parsed-as-block-level-element/4151/7), I'm proposing to update the spec to remove the `source` element as a start condition for HTML blocks.

During my research, I could not find any supporting evidence that it _should_ be starting an HTML block and the fact that it currently does is causing difficult issues when trying to render `<video>`, `<audio>`, or `<picture>` tags. More details are also in the linked discussion. 