### PR TITLE
Fix typo and add clarity around paragraph interrupt by an ordered list

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5354,7 +5354,7 @@ well.  ([reStructuredText](http://docutils.sourceforge.net/rst.html)
 takes a different approach, requiring blank lines before lists
 even inside other list items.)
 
-Interrupting a paragraph with an ordered list introduces an parsing
+Interrupting a paragraph with an ordered list introduces a parsing
 ambiguity. What looks like an ordered marker might instead be a
 a numeral at the end of a sentence, continuing rather than
 interrupting the paragraph:

--- a/spec.txt
+++ b/spec.txt
@@ -5365,7 +5365,8 @@ The number of windows in my house is
 ```
 
 To avoid this ambiguity, we allow only lists starting with `1` to
-interrupt paragraphs. Thus,
+interrupt paragraphs.  Thus,
+
 
 ```````````````````````````````` example
 The number of windows in my house is

--- a/spec.txt
+++ b/spec.txt
@@ -5354,9 +5354,18 @@ well.  ([reStructuredText](http://docutils.sourceforge.net/rst.html)
 takes a different approach, requiring blank lines before lists
 even inside other list items.)
 
-In order to solve of unwanted lists in paragraphs with
-hard-wrapped numerals, we allow only lists starting with `1` to
-interrupt paragraphs.  Thus,
+Interrupting a paragraph with an ordered list introduces an parsing
+ambiguity. What looks like an ordered marker might instead be a
+a numeral at the end of a sentence, continuing rather than
+interrupting the paragraph:
+
+``` markdown
+The number of windows in my house is
+14.  The number of doors is 6.
+```
+
+To avoid this ambiguity, we allow only lists starting with `1` to
+interrupt paragraphs. Thus,
 
 ```````````````````````````````` example
 The number of windows in my house is

--- a/spec.txt
+++ b/spec.txt
@@ -5355,7 +5355,7 @@ takes a different approach, requiring blank lines before lists
 even inside other list items.)
 
 Interrupting a paragraph with an ordered list introduces a parsing
-ambiguity. What looks like an ordered marker might instead be a
+ambiguity.  What looks like an ordered marker might instead be a
 a numeral at the end of a sentence, continuing rather than
 interrupting the paragraph:
 


### PR DESCRIPTION
Fix [typo reported](https://talk.commonmark.org/t/solve-of-unwanted/4215?u=vas) by [Dennis Howe](https://talk.commonmark.org/u/denis),

Made a more than minimal change to increase clarity as misunderstanding keeps cropping up, e.g. just [three days ago on the forum](https://talk.commonmark.org/t/nested-ordered-list-numbering/4210/1) and a [more "forceful" challenge last year](https://talk.commonmark.org/t/ordered-lists-shouldnt-trigger-for-any-number/3913).