### PR TITLE
Fix spelling of "down side" to "downside"

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1964,7 +1964,7 @@ has been found, the code block contains all of the lines after the
 opening code fence until the end of the containing block (or
 document).  (An alternative spec would require backtracking in the
 event that a closing code fence is not found.  But this makes parsing
-much less efficient, and there seems to be no real down side to the
+much less efficient, and there seems to be no real downside to the
 behavior described here.)
 
 A fenced code block may interrupt a paragraph, and does not require


### PR DESCRIPTION
Hi all,

I'm not a native English speaker, but I think "downside" is one word, not two (as in "down side"). Just noticed this while reading through the spec and I figured I could just create a PR. Feel free to ignore/close this PR if you don't think it is correct.

Thanks for the great work on the spec!
Erik