### PR TITLE
Update link to AsciiDoc

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -37,7 +37,7 @@ As Gruber writes:
 > (<http://daringfireball.net/projects/markdown/>)
 
 The point can be illustrated by comparing a sample of
-[AsciiDoc](http://www.methods.co.nz/asciidoc/) with
+[AsciiDoc](https://asciidoc.org/) with
 an equivalent sample of Markdown.  Here is a sample of
 AsciiDoc from the AsciiDoc manual:
 


### PR DESCRIPTION
Update obsolete link to AsciiDoc. The last Wayback Machine snapshot that seems to work for the old link seem to be from [August 5, 2020](https://web.archive.org/web/20200805202617/http://www.methods.co.nz/asciidoc/).