### PR TITLE
Add clarifying tests about HTML and block quotes

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2412,7 +2412,8 @@ the string `/>`.\
 7.  **Start condition:**  line begins with a complete [open tag]
 (with any [tag name] other than `pre`, `script`,
 `style`, or `textarea`) or a complete [closing tag],
-followed by zero or more spaces and tabs, followed by the end of the line.\
+all on a single line, followed by zero or more spaces and tabs,
+followed by the end of the line.\
 **End condition:** line is followed by a [blank line].
 
 HTML blocks continue until they are closed by their appropriate
@@ -2717,7 +2718,7 @@ line).  So the contents get interpreted as CommonMark:
 ````````````````````````````````
 
 
-Finally, in this case, the `<del>` tags are interpreted
+Finally, in these cases, the `<del>` tags are interpreted
 as [raw HTML] *inside* the CommonMark paragraph.  (Because
 the tag is not on a line by itself, we get inline HTML
 rather than an [HTML block].)
@@ -2726,6 +2727,18 @@ rather than an [HTML block].)
 <del>*foo*</del>
 .
 <p><del><em>foo</em></del></p>
+````````````````````````````````
+
+```````````````````````````````` example
+<del
+>
+*foo*
+</del>
+.
+<p><del
+>
+<em>foo</em>
+</del></p>
 ````````````````````````````````
 
 

--- a/spec.txt
+++ b/spec.txt
@@ -2609,7 +2609,7 @@ foo
 
 Everything until the next blank line or end of document
 gets included in the HTML block.  So, in the following
-example, what looks like a Markdown code block
+examples, what looks like a Markdown code block or block quote
 is actually part of the HTML block, which continues until a blank
 line or the end of the document is reached:
 
@@ -2623,6 +2623,15 @@ int x = 33;
 ``` c
 int x = 33;
 ```
+````````````````````````````````
+
+
+```````````````````````````````` example
+<div
+> not quoted text
+.
+<div
+> not quoted text
 ````````````````````````````````
 
 
@@ -9185,6 +9194,20 @@ foo <a href="\*">
 <a href="\"">
 .
 <p>&lt;a href=&quot;&quot;&quot;&gt;</p>
+````````````````````````````````
+
+
+A block quote can prevent a line from being parsed as inline HTML,
+even though line breaks are allowed in tags:
+
+```````````````````````````````` example
+<a
+> quoted text
+.
+<p>&lt;a</p>
+<blockquote>
+<p>quoted text</p>
+</blockquote>
 ````````````````````````````````
 
 


### PR DESCRIPTION
This result makes sense, since inline HTML being inline implies that it is parsed after block quotes, while block HTML being copy-and-pasteable implies that it should eat Markdown syntax like block quotes. However, pulldown-cmark got this wrong, and apparently so do MD4C, markdown-it, and parsedown, according to [Babelmark 3].

[Babelmark 3]: https://babelmark.github.io/?text=%3Ca%0A%3E%0A%0A%3Cdiv%0A%3E