### PR TITLE
Add symbols to unicode punctuation

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -316,9 +316,9 @@ A line containing no characters, or a line containing only spaces
 
 The following definitions of character classes will be used in this spec:
 
-A [Unicode whitespace character](@) is
-any code point in the Unicode `Zs` general category, or a tab (`U+0009`),
-line feed (`U+000A`), form feed (`U+000C`), or carriage return (`U+000D`).
+A [Unicode whitespace character](@) is a character in the Unicode `Zs` general
+category, or a tab (`U+0009`), line feed (`U+000A`), form feed (`U+000C`), or
+carriage return (`U+000D`).
 
 [Unicode whitespace](@) is a sequence of one or more
 [Unicode whitespace characters].
@@ -337,9 +337,8 @@ is `!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`,
 `[`, `\`, `]`, `^`, `_`, `` ` `` (U+005B–0060), 
 `{`, `|`, `}`, or `~` (U+007B–007E).
 
-A [Unicode punctuation character](@) is an [ASCII
-punctuation character] or anything in
-the general Unicode categories  `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
+A [Unicode punctuation character](@) is a character in the Unicode `P`
+(puncuation) or `S` (symbol) general categories.
 
 ## Tabs
 

--- a/spec.txt
+++ b/spec.txt
@@ -6342,6 +6342,21 @@ Unicode nonbreaking spaces count as whitespace, too:
 ````````````````````````````````
 
 
+Unicode symbols count as punctuation, too:
+
+```````````````````````````````` example
+*$*alpha.
+
+*£*bravo.
+
+*€*charlie.
+.
+<p>*$*alpha.</p>
+<p>*$*bravo.</p>
+<p>*$*charlie.</p>
+````````````````````````````````
+
+
 Intraword emphasis with `*` is permitted:
 
 ```````````````````````````````` example


### PR DESCRIPTION
The current commonmark definition of “ASCII punctuation character” does not only include the unicode punctuation characters within the ASCII range, but also the unicode symbol characters within the ASCII range: `$`, `+`, `<`, `=`, `>`, `^`, `` ` ``, `|`, `~`.

I think this makes sense. I think that users would not know the difference, and would indeed expect to be able to escape `*` the same as `$`.

I think it is also sensical to broaden the definition of unicode punctuation the same way, so that there’s no difference between `$`, `£`, and `€`.

Currently:

```markdown
*$*a.

*£*a.

*€*a.
```

*$*a.

*£*a.

*€*a.

Proposed: none turn into `<em>`s (note this is not a useful example, I am sure it could be possible to come up with a better one).

> Note, `S` (symbol) includes the subgroups:
>
> ```
> gc ; Sc                               ; Currency_Symbol
> gc ; Sk                               ; Modifier_Symbol
> gc ; Sm                               ; Math_Symbol
> gc ; So                               ; Other_Symbol
> ```

> Note, [all unicode characters](https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt), [all unicode categories](https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt)