### PR TITLE
correct grammar so "only" has intended meaning

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -7565,7 +7565,7 @@ the destination may be omitted:
 <p><a href=""></a></p>
 ````````````````````````````````
 
-The destination can only contain spaces if it is
+The destination can contain spaces only if it is
 enclosed in pointy brackets:
 
 ```````````````````````````````` example


### PR DESCRIPTION
A destination enclosed in pointy brackets can contain non-spaces.