### PR TITLE
RFC: Add support for display blocks & spans (for Math and diagrams)

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2355,7 +2355,82 @@ Closing code fences cannot have [info strings]:
 </code></pre>
 ````````````````````````````````
 
+## Fenced display blocks
 
+A [display fence](@) is a sequence
+of at least two consecutive dollar sign characters (`$`) 
+A [fenced display block](@) begins with a display fence,
+preceded by up to three spaces of indentation.
+
+Fenced display blocks follow the same rules as [Fenced code blocks]
+regarding the [info string], positioning, and content processing.
+
+Display blocks are intended to house code that is intended to be rendered
+rather than literally displayed. The [info string] can be used to specify
+the render engine. Example use cases are rendering TeX via MathML,
+a diagraming tool such as Marmaid or graphviz via a library, or a vector
+graphics tool.
+
+If no info string is specified, the display block should be processed as
+TeX and presented as MathML.
+
+If a rendering tool is not supported, the plain text should be presented
+exactly as an equivalent [Fenced code block]. If rendering fails, the
+engine may elect whether to present an error or fall back to rendering as
+a code block.
+
+Here is a simple example of TeX to MathML:
+
+```````````````````````````````` example
+$$
+ax^2 + bx + c
+$$
+.
+<math display="block" class="tml-display" style="display:block math;">
+  <mrow>
+    <mi>a</mi>
+    <msup>
+      <mi>x</mi>
+      <mn>2</mn>
+    </msup>
+    <mo>+</mo>
+    <mi>b</mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>c</mi>
+  </mrow>
+</math>
+````````````````````````````````
+
+The language `tex` may optionally be specified:
+
+```````````````````````````````` example
+$$tex
+\frac{a}{b}
+$$
+.
+<math display="block" class="tml-display" style="display:block math;">
+  <mfrac>
+    <mi>a</mi>
+    <mi>b</mi>
+  </mfrac>
+</math>
+````````````````````````````````
+
+More than two `$` characters may be used
+
+```````````````````````````````` example
+$$$$$
+\frac{a}{b}
+$$$$$
+.
+<math display="block" class="tml-display" style="display:block math;">
+  <mfrac>
+    <mi>a</mi>
+    <mi>b</mi>
+  </mfrac>
+</math>
+````````````````````````````````
 
 ## HTML blocks
 
@@ -6094,6 +6169,37 @@ closing backtick strings to be equal in length:
 <p>`foo<code>bar</code></p>
 ````````````````````````````````
 
+## Display Spans
+
+A [dollar string](@) is a string of one or more dollar characters (`$`).
+
+A [display span](@) begins with a dollar string and ends with a dollar
+string of equal length. The contents of a display span should be
+preprocessed in an identical way as [Code spans].
+
+Display spans are meant to contain code that can directly be rendered.
+The renderer should by default treat display span contents as TeX, and
+render it as MathML. If the renderer does not support MathML, it should
+render display spans identical to code spans.
+
+This is a simple code span:
+
+```````````````````````````````` example
+$x = \frac{a}{b}$
+.
+<math>
+  <mrow>
+    <mi>x</mi>
+    <mo>=</mo>
+  </mrow>
+  <mrow>
+    <mfrac>
+      <mi>a</mi>
+      <mi>b</mi>
+    </mfrac>
+  </mrow>
+</math>
+````````````````````````````````
 
 ## Emphasis and strong emphasis
 


### PR DESCRIPTION
This proposed change defines "display blocks" and "display spans" that are meant to process their contents for rendering in some way, rather than being displayed as raw text.

## Motivation

Math support is a discussion that seems to come up quite frequently; [pandoc](https://pandoc.org/MANUAL.html#math) has an extension, [StackExchange](https://meta.stackexchange.com/a/199469) supports math expressions via MathJax, and both [GitHub](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions) and [GitLab](https://docs.gitlab.com/ee/user/markdown.html#math) support them too. GitHub also added [support for Mermaid diagrams](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) somewhat recently. This illustrates the need for a CommonMark specification to guide further implementations.

This PR defines "display blocks" that follow the same definition rules as code blocks but are intended to render their content into a display form, rather than a verbatim representation. By default these should process the data as TeX and output MathML, but the info string can be used to change the renderer to something like `asciidoc`, `mermaid`, or `svg`.

````````markdown
<!-- this gets rendered as TeX and displayed as MathML -->
$$
x = \frac{a}{b}
$$

The same can be used inlinee $x = \frac{a}{b}$ if preferred.

<!-- this gets rendered as asciimath and displayed as MathML -->
$$asciimath
sum_(i=1)^n i^3=((n(n+1))/2)^
$$

<!-- this gets passed to a rendering library -->
<!-- >2 dollar signs are allowed -->
$$$$mermaid
graph LR
    A[Square Rect] -- Link text --> B((Circle))
    A --> C(Round Rect)
    B --> D{Rhombus}
    C --> D
$$$$

<!-- all of the below are displayed as text (likely with highlighting) and not rendered -->
```tex
x = \frac{a}{b}
```

```asciimath
sum_(i=1)^n i^3=((n(n+1))/2)^
```

```mermaid
graph LR
    A[Square Rect] -- Link text --> B((Circle))
    A --> C(Round Rect)
    B --> D{Rhombus}
    C --> D
```
````````

MathML is supported on every major browser only as of recently[^1], so providing a math implementation should be somewhat trivial. If a render engine does not support TeX or the requested renderer, it may fallback to presenting display blocks as code blocks.

The above examples are compatible with the mentioned PanDoc, GitHub, and GitLab flavored markdown, with the exception that the ````` ```mermaid ````` blocks are rendered rather than presented as plain text.

Previous discussion:

- https://talk.commonmark.org/t/ignore-latex-like-math-mode-or-parse-it/1926?u=jean
- https://talk.commonmark.org/t/math-rendering-re-visited/4086/19

[^1]: https://caniuse.com/mathml