### PR TITLE
Replace out-of-service BabelMark 2 with babelmark3

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The spec was written by John MacFarlane, drawing on
   ([peg-markdown](http://github.com/jgm/peg-markdown),
   [lunamark](http://github.com/jgm/lunamark))
 - a detailed examination of the differences between existing Markdown
-  implementations using [BabelMark 2](http://johnmacfarlane.net/babelmark2/),
+  implementations using [babelmark3](https://babelmark.github.io/),
   and
 - extensive discussions with David Greenspan, Jeff Atwood, Vicent
   Marti, Neil Williams, and Benjamin Dumke-von der Ehe.


### PR DESCRIPTION
BabelMark 2 website [1] is out of service, and on it babelmark3 is recommended as a superior replacement. The spelling of "babelmark3" follows its repo [2].

[1] https://johnmacfarlane.net/babelmark2/
[2] https://github.com/babelmark/babelmark.github.io