### PR TITLE
Relicense npm package under CC-BY-SA

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "markdown"
   ],
   "repository": "commonmark/CommonMark",
-  "license": "MIT",
   "files": [
     "index.js",
     "spec.txt"


### PR DESCRIPTION
In `package.json`, `"license": "CC-BY-SA-4.0"` (on line 6), added in commit 0a2d6af (Improved npm package: package.json and index.js., 2016-12-09), was overwritten by the latter, duplicate key `"license": "MIT"` (on line 12).

https://github.com/commonmark/commonmark-spec/blob/51d200052d0ef9ec617907b942ad8d4063874eee/package.json#L6-L12

The result is, npm package `commonmark-spec` is licensed under MIT, not CC-BY-SA 4.0. See https://www.npmjs.com/package/commonmark-spec.

Refer to [related paragraph in RFC 8259][rfc-8259-objects] for JSON format (boldface style added by me),


> An object whose names are all unique is interoperable in the sense
> that all software implementations receiving that object will agree on
> the name-value mappings.  When the names within an object are not
> unique, the behavior of software that receives such an object is
> unpredictable.  **Many implementations report the last name/value pair
> only.**  Other implementations report an error or fail to parse the
> object, and some implementations report all of the name/value pairs,
> including duplicates.

[rfc-8259-objects]: https://datatracker.ietf.org/doc/html/rfc8259#section-4