### PR TITLE
Add specification for info strings with inline code

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5881,6 +5881,10 @@ following ways:
   or ends with backtick characters, which must be separated by
   whitespace from the opening or closing backtick strings.
 
+Inline code spans may optionally be directly preceded by an [info string]
+that is wrapped in single colon characters (`` :info:`code` ``). This
+info string may not contain backtick characters.
+
 This is a simple code span:
 
 ```````````````````````````````` example
@@ -6094,6 +6098,26 @@ closing backtick strings to be equal in length:
 <p>`foo<code>bar</code></p>
 ````````````````````````````````
 
+An [info string] can be wrapped in colon (`:`) characters and given
+directly before the inline code. This spec does not mandate what to
+do with the info string, but the first word is typically used to specify
+the language. In HTML output, this is typically indicated by adding a
+class to the `code` element consisting of `language-` followed by the
+language name.
+
+```````````````````````````````` example
+:python:`foo(x, a=100)`
+.
+<p><code class="language-python">foo(x, a=100)</code></p>
+````````````````````````````````
+
+The info string may not be separated from the opening backtick.
+
+```````````````````````````````` example
+:c: `printf("foo");`
+.
+<p>:c: <code class="language-c">printf("foo");</code></p>
+````````````````````````````````
 
 ## Emphasis and strong emphasis
 


### PR DESCRIPTION
This adds RST-style colon-delimited info strings to inline code, which can be used for code highlighting

    :python:`foo("abc", a=123)`

This takes inspiration from [RST roles](https://docutils.sourceforge.io/docs/ref/rst/roles.html).