### PR TITLE
Use https scheme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ The CommonMark spec (spec.txt) and DTD (CommonMark.dtd) are
 Copyright (C) 2014-16 John MacFarlane
 
 Released under the Creative Commons CC-BY-SA 4.0 license:
-<http://creativecommons.org/licenses/by-sa/4.0/>.
+<https://creativecommons.org/licenses/by-sa/4.0/>.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CommonMark is a rationalized version of Markdown syntax,
 with a [spec][the spec] and BSD-licensed reference
 implementations in C and JavaScript.
 
-[Try it now!](http://try.commonmark.org/)
+[Try it now!](https://spec.commonmark.org/dingus/)
 
 [the spec]:  http://spec.commonmark.org/
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ implementations in C and JavaScript.
 
 [Try it now!](https://spec.commonmark.org/dingus/)
 
-[the spec]:  http://spec.commonmark.org/
+[the spec]:  https://spec.commonmark.org/
 
-For more details, see <http://commonmark.org>.
+For more details, see <https://commonmark.org>.
 
 This repository contains the spec itself, along with tools for
 running tests against the spec, and for creating HTML and PDF versions
@@ -80,7 +80,7 @@ quote, a code block, and each of the other structural elements that can
 make up a Markdown document.
 
 Because John Gruber's [canonical syntax
-description](http://daringfireball.net/projects/markdown/syntax) leaves
+description](https://daringfireball.net/projects/markdown/syntax) leaves
 many aspects of the syntax undetermined, writing a precise spec requires
 making a large number of decisions, many of them somewhat arbitrary.
 In making them, we have appealed to existing conventions and
@@ -168,9 +168,9 @@ Contributing
 ------------
 
 There is a [forum for discussing
-CommonMark](http://talk.commonmark.org); you should use it instead of
+CommonMark](https://talk.commonmark.org); you should use it instead of
 github issues for questions and possibly open-ended discussions.
-Use the [github issue tracker](http://github.com/commonmark/CommonMark/issues)
+Use the [github issue tracker](https://github.com/commonmark/CommonMark/issues)
 only for simple, clear, actionable issues.
 
 Authors
@@ -180,10 +180,10 @@ The spec was written by John MacFarlane, drawing on
 
 - his experience writing and maintaining Markdown implementations in several
   languages, including the first Markdown parser not based on regular
-  expression substitutions ([pandoc](http://github.com/jgm/pandoc)) and
+  expression substitutions ([pandoc](https://github.com/jgm/pandoc)) and
   the first markdown parsers based on PEG grammars
-  ([peg-markdown](http://github.com/jgm/peg-markdown),
-  [lunamark](http://github.com/jgm/lunamark))
+  ([peg-markdown](https://github.com/jgm/peg-markdown),
+  [lunamark](https://github.com/jgm/lunamark))
 - a detailed examination of the differences between existing Markdown
   implementations using [BabelMark 2](https://johnmacfarlane.net/babelmark2/),
   and

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "commonmark-spec",
   "version": "0.30.0",
   "description": "CommonMark spec and test cases",
-  "homepage": "http://commonmark.org",
+  "homepage": "https://commonmark.org",
   "license": "CC-BY-SA-4.0",
   "keywords": [
     "commonmark",

--- a/spec.txt
+++ b/spec.txt
@@ -578,9 +578,9 @@ raw HTML:
 
 
 ```````````````````````````````` example
-<http://example.com?find=\*>
+<https://example.com?find=\*>
 .
-<p><a href="http://example.com?find=%5C*">http://example.com?find=\*</a></p>
+<p><a href="https://example.com?find=%5C*">https://example.com?find=\*</a></p>
 ````````````````````````````````
 
 
@@ -6054,18 +6054,18 @@ But this is an HTML tag:
 And this is code:
 
 ```````````````````````````````` example
-`<http://foo.bar.`baz>`
+`<https://foo.bar.`baz>`
 .
-<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
+<p><code>&lt;https://foo.bar.</code>baz&gt;`</p>
 ````````````````````````````````
 
 
 But this is an autolink:
 
 ```````````````````````````````` example
-<http://foo.bar.`baz>`
+<https://foo.bar.`baz>`
 .
-<p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
+<p><a href="https://foo.bar.%60baz">https://foo.bar.`baz</a>`</p>
 ````````````````````````````````
 
 
@@ -7442,16 +7442,16 @@ _a `_`_
 
 
 ```````````````````````````````` example
-**a<http://foo.bar/?q=**>
+**a<https://foo.bar/?q=**>
 .
-<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
+<p>**a<a href="https://foo.bar/?q=**">https://foo.bar/?q=**</a></p>
 ````````````````````````````````
 
 
 ```````````````````````````````` example
-__a<http://foo.bar/?q=__>
+__a<https://foo.bar/?q=__>
 .
-<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
+<p>__a<a href="https://foo.bar/?q=__">https://foo.bar/?q=__</a></p>
 ````````````````````````````````
 
 
@@ -7699,13 +7699,13 @@ A link can contain fragment identifiers and queries:
 ```````````````````````````````` example
 [link](#fragment)
 
-[link](http://example.com#fragment)
+[link](https://example.com#fragment)
 
-[link](http://example.com?foo=3#frag)
+[link](https://example.com?foo=3#frag)
 .
 <p><a href="#fragment">link</a></p>
-<p><a href="http://example.com#fragment">link</a></p>
-<p><a href="http://example.com?foo=3#frag">link</a></p>
+<p><a href="https://example.com#fragment">link</a></p>
+<p><a href="https://example.com?foo=3#frag">link</a></p>
 ````````````````````````````````
 
 
@@ -7949,9 +7949,9 @@ and autolinks over link grouping:
 
 
 ```````````````````````````````` example
-[foo<http://example.com/?search=](uri)>
+[foo<https://example.com/?search=](uri)>
 .
-<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
+<p>[foo<a href="https://example.com/?search=%5D(uri)">https://example.com/?search=](uri)</a></p>
 ````````````````````````````````
 
 
@@ -8105,11 +8105,11 @@ and autolinks over link grouping:
 
 
 ```````````````````````````````` example
-[foo<http://example.com/?search=][ref]>
+[foo<https://example.com/?search=][ref]>
 
 [ref]: /uri
 .
-<p>[foo<a href="http://example.com/?search=%5D%5Bref%5D">http://example.com/?search=][ref]</a></p>
+<p>[foo<a href="https://example.com/?search=%5D%5Bref%5D">https://example.com/?search=][ref]</a></p>
 ````````````````````````````````
 
 
@@ -8778,16 +8778,16 @@ by any combination of ASCII letters, digits, or the symbols plus
 Here are some valid autolinks:
 
 ```````````````````````````````` example
-<http://foo.bar.baz>
+<https://foo.bar.baz>
 .
-<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
+<p><a href="https://foo.bar.baz">https://foo.bar.baz</a></p>
 ````````````````````````````````
 
 
 ```````````````````````````````` example
-<http://foo.bar.baz/test?q=hello&id=22&boolean>
+<https://foo.bar.baz/test?q=hello&id=22&boolean>
 .
-<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
+<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
 ````````````````````````````````
 
 
@@ -8827,9 +8827,9 @@ with their syntax:
 
 
 ```````````````````````````````` example
-<http://../>
+<https://../>
 .
-<p><a href="http://../">http://../</a></p>
+<p><a href="https://../">https://../</a></p>
 ````````````````````````````````
 
 
@@ -8843,18 +8843,18 @@ with their syntax:
 Spaces are not allowed in autolinks:
 
 ```````````````````````````````` example
-<http://foo.bar/baz bim>
+<https://foo.bar/baz bim>
 .
-<p>&lt;http://foo.bar/baz bim&gt;</p>
+<p>&lt;https://foo.bar/baz bim&gt;</p>
 ````````````````````````````````
 
 
 Backslash-escapes do not work inside autolinks:
 
 ```````````````````````````````` example
-<http://example.com/\[\>
+<https://example.com/\[\>
 .
-<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
+<p><a href="https://example.com/%5C%5B%5C">https://example.com/\[\</a></p>
 ````````````````````````````````
 
 
@@ -8906,9 +8906,9 @@ These are not autolinks:
 
 
 ```````````````````````````````` example
-< http://foo.bar >
+< https://foo.bar >
 .
-<p>&lt; http://foo.bar &gt;</p>
+<p>&lt; https://foo.bar &gt;</p>
 ````````````````````````````````
 
 
@@ -8927,9 +8927,9 @@ These are not autolinks:
 
 
 ```````````````````````````````` example
-http://example.com
+https://example.com
 .
-<p>http://example.com</p>
+<p>https://example.com</p>
 ````````````````````````````````
 
 

--- a/spec.txt
+++ b/spec.txt
@@ -8778,9 +8778,9 @@ by any combination of ASCII letters, digits, or the symbols plus
 Here are some valid autolinks:
 
 ```````````````````````````````` example
-<https://foo.bar.baz>
+<http://foo.bar.baz>
 .
-<p><a href="https://foo.bar.baz">https://foo.bar.baz</a></p>
+<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
 ````````````````````````````````
 
 

--- a/spec.txt
+++ b/spec.txt
@@ -3,7 +3,7 @@ title: CommonMark Spec
 author: John MacFarlane
 version: '0.30'
 date: '2021-06-19'
-license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+license: '[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
 # Introduction
@@ -14,7 +14,7 @@ Markdown is a plain text format for writing structured documents,
 based on conventions for indicating formatting in email
 and usenet posts.  It was developed by John Gruber (with
 help from Aaron Swartz) and released in 2004 in the form of a
-[syntax description](http://daringfireball.net/projects/markdown/syntax)
+[syntax description](https://daringfireball.net/projects/markdown/syntax)
 and a Perl script (`Markdown.pl`) for converting Markdown to
 HTML.  In the next decade, dozens of implementations were
 developed in many languages.  Some extended the original
@@ -34,7 +34,7 @@ As Gruber writes:
 > Markdown-formatted document should be publishable as-is, as
 > plain text, without looking like it's been marked up with tags
 > or formatting instructions.
-> (<http://daringfireball.net/projects/markdown/>)
+> (<https://daringfireball.net/projects/markdown/>)
 
 The point can be illustrated by comparing a sample of
 [AsciiDoc](https://asciidoc.org/) with
@@ -103,7 +103,7 @@ source, not just in the processed document.
 ## Why is a spec needed?
 
 John Gruber's [canonical description of Markdown's
-syntax](http://daringfireball.net/projects/markdown/syntax)
+syntax](https://daringfireball.net/projects/markdown/syntax)
 does not specify the syntax unambiguously.  Here are some examples of
 questions it does not answer:
 
@@ -5349,7 +5349,7 @@ by itself should be a paragraph followed by a nested sublist.
 Since it is well established Markdown practice to allow lists to
 interrupt paragraphs inside list items, the [principle of
 uniformity] requires us to allow this outside list items as
-well.  ([reStructuredText](http://docutils.sourceforge.net/rst.html)
+well.  ([reStructuredText](https://docutils.sourceforge.net/rst.html)
 takes a different approach, requiring blank lines before lists
 even inside other list items.)
 
@@ -6098,7 +6098,7 @@ closing backtick strings to be equal in length:
 ## Emphasis and strong emphasis
 
 John Gruber's original [Markdown syntax
-description](http://daringfireball.net/projects/markdown/syntax#em) says:
+description](https://daringfireball.net/projects/markdown/syntax#em) says:
 
 > Markdown treats asterisks (`*`) and underscores (`_`) as indicators of
 > emphasis. Text wrapped with one `*` or `_` will be wrapped with an HTML

--- a/tools/template.html
+++ b/tools/template.html
@@ -120,17 +120,17 @@ $$(document).ready(function() {
 </div>
 <div class="license">
 <a rel="license"
-   href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative
+   href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative
    Commons BY-SA" style="border-width: 0;"
    src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"
-   /></a><br/><span style="display: none;"><span xmlns:dct="http://purl.org/dc/terms/"
-   href="http://purl.org/dc/dcmitype/Text" property="dct:title"
+   /></a><br/><span style="display: none;"><span xmlns:dct="https://purl.org/dc/terms/"
+   href="https://purl.org/dc/dcmitype/Text" property="dct:title"
    rel="dct:type">CommonMark Spec</span> by
-   <a xmlns:cc="http://creativecommons.org/ns#"
-   href="http://spec.commonmark.org" property="cc:attributionName"
+   <a xmlns:cc="https://creativecommons.org/ns#"
+   href="https://spec.commonmark.org" property="cc:attributionName"
    rel="cc:attributionURL">John MacFarlane</a> is licensed under a
    <a rel="license"
-   href="http://creativecommons.org/licenses/by-sa/4.0/">Creative
+   href="https://creativecommons.org/licenses/by-sa/4.0/">Creative
    Commons Attribution-ShareAlike 4.0 International License</a>.</span>
 </div>
 <div id="watermark"></div>


### PR DESCRIPTION
Convert http to https scheme for all links in the repo, including examples in `spec.txt` (not sure if welcome).

The remaining http schemes are
- a link to `www.aaronsw.com` in `spec.txt` because it doesn't support https,
- all links in `changelog.txt` because I assume released changelog entries should be kept as-is, and
- a link in `CommonMark.dtd` because I know nothing about `.dtd` file format.

```
# need GNU grep to use option "-P"
grep --color=auto --exclude-dir=.git -rnP '(?<!/)http://' .
./spec.txt:1142:[original ATX implementation](http://www.aaronsw.com/2002/atx/atx.py),
./changelog.txt:311:    Discussion at <http://talk.commonmark.org/t/555>.
./changelog.txt:314:    Discussion at <http://talk.commonmark.org/t/779> and
./changelog.txt:315:    <http://talk.commonmark.org/t/1287/12>.
./changelog.txt:346:    See http://talk.commonmark.org/t/horizontal-rule-or-thematic-break/912/3
./changelog.txt:503:    <http://talk.commonmark.org/t/odd-list-behaviour/1189>).
./changelog.txt:624:    <http://talk.commonmark.org/t/903/6>. The basic idea of the change
./CommonMark.dtd:10:    xmlns CDATA #FIXED "http://commonmark.org/xml/1.0">
```