### PR TITLE
Fix unicode symbols example in emphasis syntax

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -6352,8 +6352,8 @@ Unicode symbols count as punctuation, too:
 *€*charlie.
 .
 <p>*$*alpha.</p>
-<p>*$*bravo.</p>
-<p>*$*charlie.</p>
+<p>*£*bravo.</p>
+<p>*€*charlie.</p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
If my understanding is correct, these unicode symbols should be rendered as-is. But the spec converts all symbols to $.