### PR TITLE
Fix wrong multi-line HTML tag example

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2730,12 +2730,12 @@ rather than an [HTML block].)
 
 ```````````````````````````````` example
 <del
->
+class="foo">
 *foo*
 </del>
 .
 <p><del
->
+class="foo">
 <em>foo</em>
 </del></p>
 ````````````````````````````````


### PR DESCRIPTION
For an inline HTML tag, the `>` must not be at the start of a line.