### PR TITLE
Fix a typo in emphasis Rule 1 example

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -6328,9 +6328,9 @@ These rules can be illustrated through a series of examples.
 Rule 1:
 
 ```````````````````````````````` example
-*foo bar*
+* foo bar*
 .
-<p><em>foo bar</em></p>
+<ul><li>foo bar*</li></ul>
 ````````````````````````````````
 
 


### PR DESCRIPTION
<s>I believe there is a typo here, I fixed `html` output as well. Built `spec.html`, all seems well.</s>

Edit: now that I've looked further that was a misunderstanding on my part.
