### PR TITLE
Edited opening description of 6.1. Code Spans

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5887,8 +5887,8 @@ backtick.
 ## Code spans
 
 A [backtick string](@)
-is a string of one or more backtick characters (`` ` ``) that is neither
-preceded nor followed by a backtick.
+is a string of one or more backtick characters (`` ` ``) that is not
+preceded by a backslash.
 
 A [code span](@) begins with a backtick string and ends with
 a backtick string of equal length.  The contents of the code span are


### PR DESCRIPTION
The original text stated that code spans are a string of backtick chars that cannot start with a "backtick".

As a string of backtick chars *must* start and end with a backtick (!), I assume it meant to say "backslash".