### PR TITLE
Add supplementary (non-BMP) currency symbol in Unicode symbol example

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -6372,10 +6372,13 @@ Unicode symbols count as punctuation, too:
 *£*bravo.
 
 *€*charlie.
+
+*𞋿*delta.
 .
 <p>*$*alpha.</p>
 <p>*£*bravo.</p>
 <p>*€*charlie.</p>
+<p>*𞋿*delta.</p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
Some implementations did not used to or do not recognize supplementary (non-BMP) punctuation or symbol characters.

- https://github.com/xoofx/markdig/issues/860
- https://github.com/commonmark/commonmark.js/pull/297
- https://github.com/micromark/micromark/issues/189
- https://github.com/markdown-it/markdown-it/issues/1071

The term "character" is Unicode code point, which covers supplementary characters (consume 4 bytes in UTF-8/16/32), so we have only to add an example.