### PR TITLE
Update suggested emphasis algorithm

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -9757,8 +9757,8 @@ closers:
   (This will be the potential closer closest
   to the beginning of the input -- the first one in parse order.)
 
-- Now, look back in the stack (staying above stack_bottom and
-  the openers_bottom for this delimiter type) for the
+- Now, look back in the stack (staying above `stack_bottom` and
+  the `openers_bottom` for this delimiter type) for the
   first valid potential opener, where being "valid" requires that:
 
   + the token is a potential opener; and

--- a/spec.txt
+++ b/spec.txt
@@ -9757,19 +9757,25 @@ closers:
   (This will be the potential closer closest
   to the beginning of the input -- the first one in parse order.)
 
-- Now, look back in the stack (staying above stack_bottom and the openers_bottom for this delimiter type) for the first valid potential opener, where being "valid" requires that:
+- Now, look back in the stack (staying above stack_bottom and
+  the openers_bottom for this delimiter type) for the
+  first valid potential opener, where being "valid" requires that:
 
   + the token is a potential opener; and
 
-  + the token has the same delimiter type as the current potential closer; and
+  + the token has the same delimiter type as the current potential
+    closer; and
 
   + any of the following are true:
 
-    * the closer is not a potential opener and the opener is not a potential closer; or
+    * the closer is not a potential opener and the opener is not a
+      potential closer; or
 
-    * the original length of the closing delimiter run is a multiple of 3; or
+    * the original length of the closing delimiter run is a multiple
+      of 3; or
 
-    * the original length of the opening delimiter run + the original length of the closing delimiter run is not a multiple of 3
+    * the original length of the opening delimiter run + the original
+      length of the closing delimiter run is not a multiple of 3
 
 - If one is found:
 

--- a/spec.txt
+++ b/spec.txt
@@ -9757,9 +9757,19 @@ closers:
   (This will be the potential closer closest
   to the beginning of the input -- the first one in parse order.)
 
-- Now, look back in the stack (staying above `stack_bottom` and
-  the `openers_bottom` for this delimiter type) for the
-  first matching potential opener ("matching" means same delimiter).
+- Now, look back in the stack (staying above stack_bottom and the openers_bottom for this delimiter type) for the first valid potential opener, where being "valid" requires that:
+
+  + the token is a potential opener; and
+
+  + the token has the same delimiter type as the current potential closer; and
+
+  + any of the following are true:
+
+    * the closer is not a potential opener and the opener is not a potential closer; or
+
+    * the original length of the closing delimiter run is a multiple of 3; or
+
+    * the original length of the opening delimiter run + the original length of the closing delimiter run is not a multiple of 3
 
 - If one is found:
 


### PR DESCRIPTION
Updates the recommended algorithm to match the current implementation, fixing cases such as `*foo**bar**baz*` (see #801 for full details)

The updated algorithm is based on [Commonmark's JavaScript implementation](https://github.com/commonmark/commonmark.js/blob/master/lib/inlines.js#L441), which I imagine is the same in the other languages. With the alteration, the algorithm successfully converts all of the examples in the spec file.