### PR TITLE
Tags that are void elements and phrasing content should be considered inline elements.

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2409,8 +2409,8 @@ the string `/>`.\
 **End condition:** line is followed by a [blank line].
 
 7.  **Start condition:**  line begins with a complete [open tag]
-(with any [tag name] other than `pre`, `script`,
-`style`, or `textarea`) or a complete [closing tag],
+(with any [tag name] other than `pre`, `script`, `style`, `textarea`,
+`br`, `embed`, `img`, `input` or `wbr`) or a complete [closing tag],
 all on a single line, followed by zero or more spaces and tabs,
 followed by the end of the line.\
 **End condition:** line is followed by a [blank line].


### PR DESCRIPTION
As discussed in #806, CommonMark lacks specifications for handling void elements. Since void elements are defined in HTML specifications as lacking closing tags, CommonMark should also define behavior that treats them specially.

Ref. https://html.spec.whatwg.org/multipage/syntax.html#void-elements

The existing specification can accommodate block elements. However, for inline elements (phrasing content), the current specification sometimes interprets them as HTML blocks, which is odd. Specifically, this affects five elements: `br`, `embed`, `img`, `input`, and `wbr`.

## Proposed Change

As with the changes in this pull request, it is sufficient to add a specification stating that these elements should not be treated as block elements during the seventh processing phase of HTML blocks. Adding this specification alone will ensure these elements are correctly interpreted as raw HTML within paragraphs.

Adding this specification would maintain compatibility in the test suite and is not a breaking change. Implementation adjustments and additional test cases would be necessary, but these can be addressed later.

## Reason for the 5 Elements

The elements targeted this time are `br`, `embed`, `img`, `input`, and `wbr`.

Reviewing the HTML specification, these are the only five elements among the 13 void elements that are also classified as phrasing content without special conditions. (`area`, `link`, and `meta` are excluded because they are classified as phrasing content only under specific conditions.)

Ref:
- https://html.spec.whatwg.org/multipage/dom.html#phrasing-content
- https://html.spec.whatwg.org/multipage/syntax.html#void-elements

While more might be added in the future, based on past changes, it's probably not worth worrying about. If we add these to the specification now, the likelihood of further changes appears to be low.

In the real world, it's rare for a `wbr` element to appear alone on a line, but for consistency in the specification, this approach is acceptable.